### PR TITLE
Fix typo error in requestContext injection

### DIFF
--- a/Progress.Sitefinity.AspNetCore.Widgets/Views/Shared/Components/SitefinityClassification/Default.cshtml
+++ b/Progress.Sitefinity.AspNetCore.Widgets/Views/Shared/Components/SitefinityClassification/Default.cshtml
@@ -1,7 +1,7 @@
 ﻿@using Progress.Sitefinity.AspNetCore.Mvc.Rendering
 @using Progress.Sitefinity.RestSdk.Dto
 @inject Progress.Sitefinity.AspNetCore.Web.IRenderContext renderContext;
-@inject Progress.Sitefinity.AspNetCore.Web.IRequestContext renquestContext;
+@inject Progress.Sitefinity.AspNetCore.Web.IRequestContext requestContext;
 @model Progress.Sitefinity.AspNetCore.Widgets.Models.Classification.ClassificationViewModel;
 
 <ul class="@Model.CssClass"

--- a/Progress.Sitefinity.AspNetCore.Widgets/Views/Shared/Components/SitefinitySearchBox/Default.cshtml
+++ b/Progress.Sitefinity.AspNetCore.Widgets/Views/Shared/Components/SitefinitySearchBox/Default.cshtml
@@ -1,5 +1,5 @@
 ﻿@inject Progress.Sitefinity.AspNetCore.Web.IRenderContext renderContext;
-@inject Progress.Sitefinity.AspNetCore.Web.IRequestContext renquestContext;
+@inject Progress.Sitefinity.AspNetCore.Web.IRequestContext requestContext;
 @model Progress.Sitefinity.AspNetCore.Widgets.Models.Search.SearchBoxViewModel;
 
 


### PR DESCRIPTION
Used requestContext in my project and find out that injection written as "renquest" which is not obvious at first look